### PR TITLE
Memory leak fixed

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -399,14 +399,23 @@ export class SubscriptionServer {
 
                   this.sendError(connectionContext, opId, error);
                 });
-
-              return executionIterable;
-            }).then((subscription: ExecutionIterator) => {
+              return  [ executionIterable, params ];
+            }).then(([ subscription, params ]: [ subscription: ExecutionIterator, params: ExecutionParams ]) => {
               connectionContext.operations[opId] = subscription;
-            }).then(() => {
+              return params;
+            }).then((params) => {
               // NOTE: This is a temporary code to support the legacy protocol.
               // As soon as the old protocol has been removed, this coode should also be removed.
               this.sendMessage(connectionContext, opId, MessageTypes.SUBSCRIPTION_SUCCESS, undefined);
+              // Fix:
+              // If the client did not send a GQL_STOP message,
+              // its work will forever remain in the connectionContext and a memory leak will occur.
+              // We immediately delete operation from connectionContext if it is not Subscription.
+              if ( typeof params.query === 'string') {
+                if (!params.query.startsWith('subscription'))  {
+                  this.unsubscribe(connectionContext, opId);
+                }
+              }
             }).catch((e: any) => {
               if (e.errors) {
                 this.sendMessage(connectionContext, opId, MessageTypes.GQL_DATA, { errors: e.errors });


### PR DESCRIPTION
As I have found, when a client uses the Websocket protocol for requests, sometimes it does not send a "stop" message.
If no stop message is received, the artifacts associated with the request remain in memory forever.